### PR TITLE
Remove leading slash in repo identifier

### DIFF
--- a/README
+++ b/README
@@ -53,8 +53,8 @@ Directory-based:
 		CONF is "fugit.d"
 
 		$ git clone ssh://host/repo/identifier
-		=> Repo identifier is "/repo/identifier"
-		=> Config file is "fugit.d/_repo_identifier.conf"
+		=> Repo identifier is "repo/identifier"
+		=> Config file is "fugit.d/repo_identifier.conf"
 
 	Config files for repositories should contain these 3 lines
 	REAL=<path>			//Path to the repo on disk

--- a/fugit
+++ b/fugit
@@ -40,10 +40,11 @@ contains_conffile(){
 # $2 repo
 # $3 username
 check_acl(){
+	REPONAME=${2#/}
 	# If using confdir, use confdir ACL
 	if [ -d "$CONF" ]; then
 		# Fix up the repository name
-		REPONAME=$(echo "$2" | tr '/' '_')
+		REPONAME=$(echo "$REPONAME" | tr '/' '_')
 		# Read the config file
 		if [ -r "$CONF/$REPONAME.conf" ]; then
 			eval $(cat "$CONF/$REPONAME.conf")
@@ -63,7 +64,7 @@ check_acl(){
 		return 1
 	else
 		# Use conffile syntax
-		eval $(grep --fixed-strings --line-regexp --after-context=3 "REPO $2" $CONFFILE | tail -n +2)
+		eval $(grep --fixed-strings --line-regexp --after-context=3 "REPO $REPONAME" $CONFFILE | tail -n +2)
 		if [ "$1" == "pull" ]; then
 			contains_conffile "$PULL" "$3"
 			return $?

--- a/fugit.conf
+++ b/fugit.conf
@@ -1,9 +1,9 @@
-REPO /fugit
+REPO fugit
 REAL=~/repo
 PUSH="cbdev testkey1"
 PULL="cbdev testkey1"
 
-REPO /testrepo
+REPO testrepo
 REAL=~/testrepo
 PUSH="testkey1"
 PULL="testkey1"


### PR DESCRIPTION
The leading slash stems from the ssh://user@host/repo URL.
The alternative form user@host:repo does not include it.

Removing it solves compatibility issues.

Fixes #12  